### PR TITLE
String translate + many component name matching fixes

### DIFF
--- a/galfit_parser.py
+++ b/galfit_parser.py
@@ -26,16 +26,16 @@ class GalfitComponent(object):
         headerkeys = [i for i in galfitheader.keys()]
         comp_params = []
         for i in headerkeys:
-            if str(component_number) + '_' in i:
+            if i.startswith(str(component_number)+'_'):
                 comp_params.append(i)
         for param in comp_params:
             val = galfitheader[param]
             #we know that val is a string formatted as 'result +/- uncertainty'
             #if val is fixed in GalFit, it is formatted as '[result]'
             paramsplit = param.split('_')
-            
+
             # If there's some numerical error, should output a warning (*)
-            
+
             if '[' in val:     #fixed parameter
                 val = val.translate(None,'[]*')
                 setattr(self,paramsplit[1].lower(),float(val))
@@ -44,7 +44,7 @@ class GalfitComponent(object):
                 val = val.translate(None,'*').split()
                 setattr(self,paramsplit[1].lower(),float(val[0]))
                 setattr(self,paramsplit[1].lower() + '_err',float(val[2]))
-            
+
 class GalfitResults(object):
     """
     This class stores galfit results information
@@ -67,7 +67,7 @@ class GalfitResults(object):
         assert True == galfit_in_comments
         assert "COMP_1" in galfitheader
         #now we've convinced ourselves that this is probably a galfit file
-        
+
         self.galfit_fits_file = galfit_fits_file
         #read in the input parameters
         self.input_initfile = galfitheader['INITFILE']
@@ -79,13 +79,13 @@ class GalfitResults(object):
         self.input_fitsect = galfitheader["FITSECT"]
         self.input_convbox = galfitheader["CONVBOX"]
         self.input_magzpt = galfitheader["MAGZPT"]
-        
+
         #read in the chi-square value
         self.chisq = galfitheader["CHISQ"]
         self.ndof = galfitheader["NDOF"]
         self.nfree = galfitheader["NFREE"]
         self.reduced_chisq = galfitheader["CHI2NU"]
-        
+
         #find the number of components
         num_components = 1 #already verified above
         while True:
@@ -99,4 +99,3 @@ class GalfitResults(object):
             setattr(self,"component_" + str(i),GalfitComponent(galfitheader,i))
 
         hdulist.close()
-        

--- a/galfit_parser.py
+++ b/galfit_parser.py
@@ -2,6 +2,9 @@
 # This module will read in the galfit best fit values and uncertainties
 #
 
+import sys
+pyvers = sys.version_info[0]
+
 from astropy.io import fits
 '''
   to create an object containing galfit results, use obj = GalfitResult('<output block fits file>')
@@ -37,11 +40,21 @@ class GalfitComponent(object):
             # If there's some numerical error, should output a warning (*)
 
             if '[' in val:     #fixed parameter
-                val = val.translate(None,'[]*')
+                if (pyvers == 2):
+                    val = val.translate(None,'[]*')
+                elif (pyvers == 3):
+                    val = val.translate(str.maketrans('', '', '[]*'))
+                else:
+                    raise ValueError("python version {} not recognized!".format(pyvers))
                 setattr(self,paramsplit[1].lower(),float(val))
                 setattr(self,paramsplit[1].lower() + '_err',None)
             else:              #normal variable parameter
-                val = val.translate(None,'*').split()
+                if (pyvers == 2):
+                    val = val.translate(None,'*').split()
+                elif (pyvers == 3):
+                    val = val.translate(str.maketrans('', '', '*')).split()
+                else:
+                    raise ValueError("python version {} not recognized!".format(pyvers))
                 setattr(self,paramsplit[1].lower(),float(val[0]))
                 setattr(self,paramsplit[1].lower() + '_err',float(val[2]))
 
@@ -86,6 +99,9 @@ class GalfitResults(object):
         self.nfree = galfitheader["NFREE"]
         self.reduced_chisq = galfitheader["CHI2NU"]
 
+        #read in galfit flags:
+        self.galfit_flags = galfitheader["FLAGS"].split(" ")
+        
         #find the number of components
         num_components = 1 #already verified above
         while True:


### PR DESCRIPTION
Hi Alex,

First, thanks for writing a nice python galfit parsers!

I've made a few changes that fix some problems:
* The current string translation code to handle fixed parameters no longer works in Python version 3. I've added a fix that includes a split for the py2 vs py3 string.translation functionality
* The existing component number matching will lead to namespace clashes if there are more then 10 components. A fix is added to directly check if the component header keywords starts with "NCOMP_".
* The array of Galfit flags weren't being included in the result class, so are now included as "res.galfit_flags"

Thanks for the consideration,
--Sedona